### PR TITLE
use default netx timeout when dial direct

### DIFF
--- a/detour.go
+++ b/detour.go
@@ -128,7 +128,7 @@ func SetCountry(country string) {
 func Dialer(d dialFunc) dialFunc {
 	return func(network, addr string) (conn net.Conn, err error) {
 		if allowsDirect(addr) {
-			return netx.DialTimeout(network, addr, TimeoutToDetour)
+			return netx.Dial(network, addr)
 		}
 		dc := &Conn{dialDetour: d, network: network, addr: addr}
 		if !whitelisted(addr) {


### PR DESCRIPTION
@myleshorton found this and commented at https://github.com/getlantern/detour/pull/3/files#r110781538.

In long term we can pass context all the way to here, but now let's just use the default timeout. @oxtoacart how do you think?