### PR TITLE
Don't detour if client closed connection

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -40,6 +40,7 @@ func init() {
 var defaultDetector = Detector{
 	DNSPoisoned: func(net.Conn) bool { return false },
 	TamperingSuspected: func(err error) bool {
+		log.Tracef("Checking if tampering is suspected for %v", err)
 		if ne, ok := err.(net.Error); ok && ne.Timeout() {
 			return true
 		}

--- a/detour.go
+++ b/detour.go
@@ -99,12 +99,14 @@ const (
 	stateInitial = iota
 	stateDirect
 	stateDetour
+	stateClosed
 )
 
 var statesDesc = []string{
 	"initially",
 	"directly",
 	"detoured",
+	"closed",
 }
 
 // SetCountry sets the ISO 3166-1 alpha-2 country code
@@ -312,6 +314,7 @@ func (dc *Conn) Close() error {
 			AddToWl(dc.addr, true)
 		}
 	}
+	dc.setState(stateClosed)
 	conn := dc.getConn()
 	if conn == nil {
 		return nil


### PR DESCRIPTION
For getlantern/lantern-internal#3070. Basically this ensures that if the user of the detoured connection closes the connections and then later attempts to read from it, we don't treat that like an error that should lead to detouring.