### PR TITLE
Supporting new Iran censor address in blocking detection

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -3,6 +3,7 @@ package detour
 import (
 	"bytes"
 	"net"
+	"regexp"
 )
 
 // Detector is just a set of rules to check if a site is potentially blocked or not
@@ -12,24 +13,29 @@ type Detector struct {
 	FakeResponse       func([]byte) bool
 }
 
-var detectors = make(map[string]*Detector)
-
-var iranRedirectAddr = "10.10.34.34:80"
+var (
+	detectors                = make(map[string]*Detector)
+	iranRedirectAddrs        = []string{"10.10.34.34:80", "10.10.34.36:80"}
+	iranBlockingMessageRegex = regexp.MustCompile(`<iframe src="http://10\.10\.34.+`)
+	http403                  = []byte("HTTP/1.1 403 Forbidden")
+)
 
 func init() {
-	http403 := []byte("HTTP/1.1 403 Forbidden")
-	iranIFrame := []byte(`<iframe src="http://10.10.34.34`)
 	// see tests and https://github.com/getlantern/lantern/issues/2099#issuecomment-78015418
 	// for the facts behind detection rules for Iran
 	detectors["IR"] = &Detector{
 		DNSPoisoned: func(c net.Conn) bool {
 			if ra := c.RemoteAddr(); ra != nil {
-				return ra.String() == iranRedirectAddr
+				for _, iranRedirectAddr := range iranRedirectAddrs {
+					if ra.String() == iranRedirectAddr {
+						return true
+					}
+				}
 			}
 			return false
 		},
 		FakeResponse: func(b []byte) bool {
-			return bytes.HasPrefix(b, http403) && bytes.Contains(b, iranIFrame)
+			return bytes.HasPrefix(b, http403) && iranBlockingMessageRegex.Match(b)
 		},
 		TamperingSuspected: func(err error) bool {
 			return false

--- a/detour_test.go
+++ b/detour_test.go
@@ -22,10 +22,10 @@ var (
 	directMsg string = "hello direct"
 	detourMsg string = "hello detour"
 	iranResp  string = `HTTP/1.1 403 Forbidden
-Connection:close
-
-<html><head><meta http-equiv="Content-Type" content="text/html; charset=windows-1256"><title>M1-6
-</title></head><body><iframe src="http://10.10.34.34?type=Invalid Site&policy=MainPolicy " style="width: 100%; height: 100%" scrolling="no" marginwidth="0" marginheight="0" frameborder="0" vspace="0" hspace="0"></iframe></body></html>Connection closed by foreign host.`
+	Connection:close
+	
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=windows-1256"><title>NTR1</title>
+</head><body><iframe src="http://10.10.34.36?type=InvalidKeyword&policy=MainPolicy " style="width: 100%; height: 100%" scrolling="no" marginwidth="0" marginheight="0" frameborder="0" vspace="0" hspace="0"></iframe></body></html>Connection closed by foreign host.`
 )
 
 func proxyTo(proxiedURL string) dialFunc {
@@ -163,9 +163,11 @@ func TestIranRules(t *testing.T) {
 
 	// this test can verifies dns hijack detection if runs inside Iran,
 	// but only will time out and detour if runs outside Iran
-	resp, err = client.Get("http://" + iranRedirectAddr)
-	if assert.NoError(t, err, "should not error if dns hijacked in Iran") {
-		assertContent(t, resp, detourMsg, "should detour if dns hijacked in Iran")
+	for _, iranRedirectAddr := range iranRedirectAddrs {
+		resp, err = client.Get("http://" + iranRedirectAddr)
+		if assert.NoError(t, err, "should not error if dns hijacked in Iran") {
+			assertContent(t, resp, detourMsg, "should detour if dns hijacked in Iran")
+		}
 	}
 }
 


### PR DESCRIPTION
For getlantern/lantern-internal#4025

It looks like Iran is now using a new IP address `10.10.34.36` instead of `10.10.34.34`. This adds support for considering both for blocking detection.